### PR TITLE
Fix cnc build break after geoipdb override feature is pulled

### DIFF
--- a/cnc.go
+++ b/cnc.go
@@ -687,7 +687,7 @@ func main() {
 	}
 	defer session.Close()
 
-	geo, err = geoipdb.NewHandler(time.Second * 5)
+	geo, err = geoipdb.NewHandler(nil, time.Second * 5)
 	if err != nil {
 		log.Fatalf("failed to get a geoipdb handler: %s", err)
 	}


### PR DESCRIPTION
@sajal This pull request fixes the build break of cnc after [geoipdb asn override pull request](/turbobytes/geoipdb/pull/15) is accepted.

This is just a quick fix for the build break; the override feature in cnc is not yet implemented.

Reference #11 