### PR TITLE
Enable local overrides of ASN descriptions in cnc

### DIFF
--- a/cnc.go
+++ b/cnc.go
@@ -687,7 +687,10 @@ func main() {
 	}
 	defer session.Close()
 
-	geo, err = geoipdb.NewHandler(nil, time.Second * 5)
+	geo, err = geoipdb.NewHandler(
+		session.DB("dnsdist").C("geoipdb"),
+		time.Second * 5,
+	)
 	if err != nil {
 		log.Fatalf("failed to get a geoipdb handler: %s", err)
 	}


### PR DESCRIPTION
@sajal

I used mongo shell to create test override values locally, and confirmed that dev mode cnc correctly shows overriden descriptions in /dns/ test output.

As I understand this merge completes the required enhancement in pulse repository. (Of course there is more work to do in other repos.)

Fixes #11