### PR TITLE
Implement fixipv6endpoint() as temporary workaround to #5

### DIFF
--- a/utils/curl.go
+++ b/utils/curl.go
@@ -136,9 +136,12 @@ func fixipv6endpoint(endpoint string) string {
 		return endpoint
 	}
 	//Figure out if input contains : or %
-	//Logic from https://golang.org/src/net/ipsock.go?s=5260:5303#L183
-	if strings.ContainsAny(endpoint, ":%") {
-		return endpoint + ":443"
+	//Logic from upstream bugfix https://github.com/golang/net/commit/e31bd588d1077ee66a958c0ad3a235f2084b4195
+	if strings.HasPrefix(endpoint, "[") && strings.HasSuffix(endpoint, "]") {
+		//Logic from https://golang.org/src/net/ipsock.go?s=5260:5303#L183
+		if strings.ContainsAny(endpoint, ":%") {
+			return endpoint + ":443"
+		}
 	}
 	return endpoint
 }

--- a/utils/curl_test.go
+++ b/utils/curl_test.go
@@ -62,6 +62,33 @@ func TestCurlLocalBlock(t *testing.T) {
 	}
 }
 
+//Tests if fixipv6endpoint() is behaving correctly or not.
+func TestFixipv6endpoint(t *testing.T) {
+	//Test endpoints that should *not* be changed
+	valid_endpoints := []string{
+		"bar.foo.com",
+		"[bar.foo.com]",
+		"bar.foo.com:123",
+		"1.1.1.1",
+		"1.1.1.1:432",
+		"[2400:cb00:2048:1::c629:d7a2]:443",
+	}
+	for _, ep := range valid_endpoints {
+		fixed := fixipv6endpoint(ep)
+		if fixed != ep {
+			t.Errorf("%s should remain the same, got %s", ep, fixed)
+		}
+	}
+	//Test endpoints that should be changed
+	invalid_endpoints := map[string]string{"[2400:cb00:2048:1::c629:d7a2]": "[2400:cb00:2048:1::c629:d7a2]:443"}
+	for ep, expected := range invalid_endpoints {
+		fixed := fixipv6endpoint(ep)
+		if fixed != expected {
+			t.Errorf("%s should become %s, got %s", ep, expected, fixed)
+		}
+	}
+}
+
 // Timing tests require hitting an external url towards TurboBytes mock server.
 // Maybe this is not a good idea. Perhaps we need a local mocker.
 // Perhaps wait for https://go-review.googlesource.com/#/c/29440/ to land in release to help with local mock server.

--- a/utils/curl_test.go
+++ b/utils/curl_test.go
@@ -72,6 +72,7 @@ func TestFixipv6endpoint(t *testing.T) {
 		"1.1.1.1",
 		"1.1.1.1:432",
 		"[2400:cb00:2048:1::c629:d7a2]:443",
+		"2400:cb00:2048:1::c629:d7a2",
 	}
 	for _, ep := range valid_endpoints {
 		fixed := fixipv6endpoint(ep)


### PR DESCRIPTION
Change endpoint from `[IPv6]` to `[IPv6]:443` for https test.